### PR TITLE
Fix commit hash burnin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Build
         uses: borales/actions-yarn@v4
+        env:
+          COMMIT_SHA: $(git rev-parse --short "${{ github.sha }}")
         with:
           cmd: build
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,27 +8,33 @@ jobs:
       deployments: write
     name: Publish to Cloudflare Pages
     steps:
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Setup Node 18
+      - name: Set COMMIT_SHA in ENV
+        run:
+          | echo "COMMIT_SHA=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_ENV
+
+      - name: Echo COMMIT_SHA
+        run:
+          | echo $COMMIT_SHA
+
+      - name: Setup Node v18
         uses: actions/setup-node@v3
         with:
           node-version: 18
 
-      - name: Install dependencies
+      - name: Install project dependencies
         uses: borales/actions-yarn@v4
         with:
           cmd: install
 
-      - name: Build
+      - name: Build project
         uses: borales/actions-yarn@v4
-        env:
-          COMMIT_SHA: $(git rev-parse --short "${{ github.sha }}")
         with:
           cmd: build
 
-      - name: Publish
+      - name: Publish to Cloudflare
         uses: cloudflare/pages-action@v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set COMMIT_SHA in ENV
-        run:
-          | echo "COMMIT_SHA=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_ENV
+        run: |
+          echo "COMMIT_SHA=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_ENV
 
       - name: Echo COMMIT_SHA
         run:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,8 @@ jobs:
           echo "COMMIT_SHA=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_ENV
 
       - name: Echo COMMIT_SHA
-        run:
-          | echo $COMMIT_SHA
+        run: |
+          echo $COMMIT_SHA
 
       - name: Setup Node v18
         uses: actions/setup-node@v3

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -15,7 +15,7 @@ const config: GatsbyConfig = {
     siteDescription: `Random bits of knowledge.`,
     siteLanguage: `en`,
     author: `Ray Chen`,
-    version: process.env.CF_PAGES_COMMIT_SHA ?? `local`,
+    version: process.env.COMMIT_SHA ?? `local`,
   },
   trailingSlash: `never`,
   plugins: [


### PR DESCRIPTION
This replaces `CF_PAGES_COMMIT_SHA` with `COMMIT_SHA` injected during build step in GHA. The former is no longer relevant - it's only available when building in CF Pages, but I'm now building and publishing manually via GHA (see #9 for context).